### PR TITLE
removed deprecated byid

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ In [2]: rb = RadioBrowser()
 
 In [3]: rb.station_search(params={'name': 'BBC Radio 1', 'nameExact': 'true'})                
 Out[3]: 
-[{'id': '64094',
-  'changeuuid': '4f7e4097-4354-11e8-b74d-52543be04c81',
+[{'changeuuid': '4f7e4097-4354-11e8-b74d-52543be04c81',
   'stationuuid': '96062a7b-0601-11e8-ae97-52543be04c81',
   'name': 'BBC Radio 1',
   'url': 'http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio1_mf_p',
@@ -45,10 +44,9 @@ Out[3]:
   'clickcount': '123',
   'clicktrend': '-12'}]
   
-In [4]: rb.stations_byid('92585')
+In [4]: rb.stations_byuuid('96062a7b-0601-11e8-ae97-52543be04c81')
 Out[4]:
-[{'id': '92585',
-  'changeuuid': 'e78eb8c0-1a25-11e8-a334-52543be04c81',
+[{'changeuuid': 'e78eb8c0-1a25-11e8-a334-52543be04c81',
   'stationuuid': '9621d43e-0601-11e8-ae97-52543be04c81',
   'name': 'Radio Maria Südtirol',
   'url': 'http://s1.shoutitaly.com:8020/;',

--- a/pyradios/radios.py
+++ b/pyradios/radios.py
@@ -150,12 +150,6 @@ class RadioBrowser:
             )
         return request(endpoint, **self.config)
 
-    def stations_byid(self, id):
-        endpoint = self.builder.produce_endpoint(
-            endpoint="stations", by="byid", search_term=id
-        )
-        return request(endpoint, **self.config)
-
     def stations_byuuid(self, uuid):
         endpoint = self.builder.produce_endpoint(
             endpoint="stations", by="byuuid", search_term=uuid

--- a/tests/endpoint_builder.py
+++ b/tests/endpoint_builder.py
@@ -71,13 +71,6 @@ class TestEndPoint(unittest.TestCase):
         result = self.builder.produce_endpoint(endpoint="stations")
         self.assertEqual(result, expected)
 
-    def test_stations_byid(self):
-        expected = "json/stations/byid/0000"
-        result = self.builder.produce_endpoint(
-            endpoint="stations", by="byid", search_term="0000"
-        )
-        self.assertEqual(result, expected)
-
     def test_stations_byuuid(self):
         expected = "json/stations/byuuid/0000"
         result = self.builder.produce_endpoint(


### PR DESCRIPTION
calls to byid are not supported on the new servers, only uuids are consistend accross multiple servers.