### PR TITLE
 Method to pass a Python list to tag_list search

### DIFF
--- a/pyradios/radios.py
+++ b/pyradios/radios.py
@@ -367,19 +367,19 @@ class RadioBrowser:
         kwargs.update({"tag": tag, "tag_exact": exact})
         return self.search(**kwargs)
 
-    def stations_by_tagList(self, tagList, **kwargs):
+    def stations_by_tag_list(self, tag_list, **kwargs):
         """Lists all radio stations by tag. Must match all tags exactly.
 
         Args:
-            tagList (list): A list of names of tags.
+            tag_list (list): A list of names of tags.
 
         Returns:
             list: Stations.
         See details:
             https://de1.api.radio-browser.info/#List_of_radio_stations
         """
-        tagList = ",".join(tagList)
-        kwargs.update({"tag_list": tagList})
+        tag_list = ",".join(tag_list)
+        kwargs.update({"tag_list": tag_list})
         return self.search(**kwargs)
 
 

--- a/pyradios/radios.py
+++ b/pyradios/radios.py
@@ -367,6 +367,22 @@ class RadioBrowser:
         kwargs.update({"tag": tag, "tag_exact": exact})
         return self.search(**kwargs)
 
+    def stations_by_tagList(self, tagList, **kwargs):
+        """Lists all radio stations by tag. Must match all tags exactly.
+
+        Args:
+            tagList (list): A list of names of tags.
+
+        Returns:
+            list: Stations.
+        See details:
+            https://de1.api.radio-browser.info/#List_of_radio_stations
+        """
+        tagList = ",".join(tagList)
+        kwargs.update({"tag_list": tagList})
+        return self.search(**kwargs)
+
+
     def click_counter(self, stationuuid):
         """Increase the click count of a station by one.
 
@@ -374,7 +390,7 @@ class RadioBrowser:
         playing a stream to mark the stream more popular than others.
         Every call to this endpoint from the same IP address and for
         the same station only gets counted once per day. The call will
-        return detailed information about the stream, supported output
+        return detailed information about thestat stream, supported output
         formats: JSON
 
         Args:

--- a/pyradios/radios.py
+++ b/pyradios/radios.py
@@ -390,7 +390,7 @@ class RadioBrowser:
         playing a stream to mark the stream more popular than others.
         Every call to this endpoint from the same IP address and for
         the same station only gets counted once per day. The call will
-        return detailed information about thestat stream, supported output
+        return detailed information about the stat stream, supported output
         formats: JSON
 
         Args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.22.0
+responses>=0.12.1

--- a/tests/test_radio_browser.py
+++ b/tests/test_radio_browser.py
@@ -156,3 +156,43 @@ def test_request_station_byuuid(rb):
 
     assert len(resp[0]) == len(response_keys)
     assert super_set.issuperset(response_keys)
+
+
+def test_request_station_tagList(rb):
+
+    tagList = ["New York City", "Jazz"]
+    resp = rb.stations_by_tagList(tagList)
+
+    super_set = {
+        "changeuuid",
+        "stationuuid",
+        "name",
+        "url",
+        "url_resolved",
+        "homepage",
+        "favicon",
+        "tags",
+        "country",
+        "countrycode",
+        "state",
+        "language",
+        "votes",
+        "lastchangetime",
+        "codec",
+        "bitrate",
+        "hls",
+        "lastcheckok",
+        "lastchecktime",
+        "lastcheckoktime",
+        "lastlocalchecktime",
+        "clicktimestamp",
+        "clickcount",
+        "clicktrend",
+    }
+    response_keys = resp[0].keys()
+    tags = set(resp[0]['tags'].split(","))
+    test_tagList = [tag.lower() for tag in tagList] #API is not case-sensitive
+
+    assert len(resp[0]) == len(response_keys)
+    assert super_set.issuperset(response_keys)
+    assert tags.issuperset(test_tagList)

--- a/tests/test_radio_browser.py
+++ b/tests/test_radio_browser.py
@@ -158,10 +158,10 @@ def test_request_station_byuuid(rb):
     assert super_set.issuperset(response_keys)
 
 
-def test_request_station_tagList(rb):
+def test_request_station_tag_list(rb):
 
-    tagList = ["New York City", "Jazz"]
-    resp = rb.stations_by_tagList(tagList)
+    tag_list = ["New York City", "Jazz"]
+    resp = rb.stations_by_tag_list(tag_list)
 
     super_set = {
         "changeuuid",
@@ -191,8 +191,8 @@ def test_request_station_tagList(rb):
     }
     response_keys = resp[0].keys()
     tags = set(resp[0]['tags'].split(","))
-    test_tagList = [tag.lower() for tag in tagList] #API is not case-sensitive
+    test_tag_list = [tag.lower() for tag in tag_list] #API is not case-sensitive
 
     assert len(resp[0]) == len(response_keys)
     assert super_set.issuperset(response_keys)
-    assert tags.issuperset(test_tagList)
+    assert tags.issuperset(test_tag_list)


### PR DESCRIPTION
I saw that you can use the tagList search feature of the API using RadioBrowser.search(tag_list="tag1,tag2"), but I thought it might be useful to be able to directly pass a Python list instead of having to pre-convert to a string first.

I wrote a test as well, but realized that requirements.txt didn't include responses as a package requirement. Not sure if this was on purpose, but I added it to the list. Feel free to drop.

Hope this is useful. Happy to make edits.