### PR TITLE
Include requirements-dev.txt in manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include *.py
 include README.md
 include LICENSE
 include requirements.txt
-
+include requirements-dev.txt 


### PR DESCRIPTION
Building binaries for conda fails because it could not find requirements-dev.txt in source