### PR TITLE
Remove Python 3.6 support from the GH Actions workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Remove Python 3.6 from the list of Python versions supported in
the GitHub Actions workflow, as Python 3.6 has reached end-of-life
and is no longer supported with security updates.
