### PR TITLE
Exclude test-related packages from package search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     author_email="andreztz@gmail.com",
     url="https://github.com/andreztz/pyradios",
     license="MIT",
-    packages=find_packages(),
+    packages=find_packages(exclude=["test*"]),
     install_requires=required(),
     extras_require={'dev': required('-dev')},
     classifiers=[


### PR DESCRIPTION
This change ensures that test-related packages are not included in the distribution.
